### PR TITLE
Added a way to set segment width distribution

### DIFF
--- a/Example/Tests/Tests.swift
+++ b/Example/Tests/Tests.swift
@@ -2,28 +2,55 @@ import UIKit
 import XCTest
 import XMSegmentedControl
 
+@testable
+import XMSegmentedControl_Example
+
 class Tests: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        // Put setup code here. This method is called before the invocation of each test method in the class.
     }
     
     override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
     }
     
-    func testExample() {
-        // This is an example of a functional test case.
-        XCTAssert(true, "Pass")
+    func testContentTypeHybrid() {
+        let titles = ["Hello", "World", "Two"]
+        let icons = [UIImage(named: "icon1")!, UIImage(named: "icon2")!, UIImage(named: "icon3")!]
+
+        let frame = CGRect(x: 0, y: 114, width: 375, height: 44)
+        let segmentedControl = XMSegmentedControl(frame: frame, segmentContent: (titles, icons), selectedItemHighlightStyle: XMSelectedItemHighlightStyle.BottomEdge)
+        XCTAssertEqual(titles, segmentedControl.segmentContent.text)
+        XCTAssertEqual(icons, segmentedControl.segmentContent.icon)
+        XCTAssertEqual(segmentedControl.contentType, XMContentType.Hybrid)
     }
-    
-    func testPerformanceExample() {
-        // This is an example of a performance test case.
-        self.measureBlock() {
-            // Put the code you want to measure the time of here.
-        }
+
+    func testContentTypeHybridVertical() {
+        let titles = ["Hello", "World", "Two"]
+        let icons = [UIImage(named: "icon1")!, UIImage(named: "icon2")!, UIImage(named: "icon3")!]
+
+        let frame = CGRect(x: 0, y: 114, width: 375, height: 44)
+        let segmentedControl = XMSegmentedControl(frame: frame, verticalSegmentContent: (titles, icons), selectedItemHighlightStyle: XMSelectedItemHighlightStyle.BottomEdge)
+        XCTAssertEqual(titles, segmentedControl.segmentContent.text)
+        XCTAssertEqual(icons, segmentedControl.segmentContent.icon)
+        XCTAssertEqual(segmentedControl.contentType, XMContentType.HybridVertical)
     }
-    
+
+    func testContentTypeText() {
+        let titles = ["Hello", "World", "Two"]
+
+        let segmentedControl = XMSegmentedControl(frame: CGRect(x: 0, y: 224, width: 375, height: 44), segmentTitle: titles, selectedItemHighlightStyle: XMSelectedItemHighlightStyle.TopEdge)
+        XCTAssertEqual(titles, segmentedControl.segmentTitle)
+        XCTAssertEqual(segmentedControl.contentType, XMContentType.Text)
+    }
+
+    func testContentTypeIcon() {
+        let icons: [UIImage] = [UIImage(named: "icon1")!, UIImage(named: "icon2")!, UIImage(named: "icon3")!, UIImage(named: "icon4")!, UIImage(named: "icon5")!, UIImage(named: "icon6")!]
+
+        let segmentedControl = XMSegmentedControl(frame: CGRect(x: 0, y: 274, width: 375, height: 44), segmentIcon: icons, selectedItemHighlightStyle: XMSelectedItemHighlightStyle.Background)
+        XCTAssertEqual(icons, segmentedControl.segmentIcon)
+        XCTAssertEqual(segmentedControl.contentType, XMContentType.Icon)
+    }
+
 }

--- a/Example/Tests/Tests.swift
+++ b/Example/Tests/Tests.swift
@@ -22,7 +22,7 @@ class Tests: XCTestCase {
         let frame = CGRect(x: 0, y: 114, width: 375, height: 44)
         let segmentedControl = XMSegmentedControl(frame: frame, segmentContent: (titles, icons), selectedItemHighlightStyle: XMSelectedItemHighlightStyle.BottomEdge)
         XCTAssertEqual(titles, segmentedControl.segmentContent.text)
-        XCTAssertEqual(icons, segmentedControl.segmentContent.icon)
+        XCTAssertEqual(icons.count, segmentedControl.segmentContent.icon.count)
         XCTAssertEqual(segmentedControl.contentType, XMContentType.Hybrid)
     }
 
@@ -33,7 +33,7 @@ class Tests: XCTestCase {
         let frame = CGRect(x: 0, y: 114, width: 375, height: 44)
         let segmentedControl = XMSegmentedControl(frame: frame, verticalSegmentContent: (titles, icons), selectedItemHighlightStyle: XMSelectedItemHighlightStyle.BottomEdge)
         XCTAssertEqual(titles, segmentedControl.segmentContent.text)
-        XCTAssertEqual(icons, segmentedControl.segmentContent.icon)
+        XCTAssertEqual(icons.count, segmentedControl.segmentContent.icon.count)
         XCTAssertEqual(segmentedControl.contentType, XMContentType.HybridVertical)
     }
 

--- a/Example/XMSegmentedControl.xcodeproj/project.pbxproj
+++ b/Example/XMSegmentedControl.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		2500FAB01C0A59C400984852 /* CHANGELOG.md in Sources */ = {isa = PBXBuildFile; fileRef = 2500FAAF1C0A59C400984852 /* CHANGELOG.md */; };
 		3A789FCA18F05D27B01AB6A7 /* Pods_XMSegmentedControl_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 19ABD2CEA41BD1DC63B4036A /* Pods_XMSegmentedControl_Example.framework */; };
 		581D5851FC91AE2B2BF2A541 /* Pods_XMSegmentedControl_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8799F6D568A188459790D9F3 /* Pods_XMSegmentedControl_Tests.framework */; };
 		607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD51AFB9204008FA782 /* AppDelegate.swift */; };
@@ -363,7 +362,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				607FACD81AFB9204008FA782 /* ViewController.swift in Sources */,
-				2500FAB01C0A59C400984852 /* CHANGELOG.md in Sources */,
 				607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/XMSegmentedControl.xcodeproj/project.pbxproj
+++ b/Example/XMSegmentedControl.xcodeproj/project.pbxproj
@@ -519,10 +519,6 @@
 			baseConfigurationReference = 2FC7E6F5C75A0B71C796A9A5 /* Pods-XMSegmentedControl_Tests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
@@ -540,10 +536,6 @@
 			baseConfigurationReference = EF8C28696452355C21BF5855 /* Pods-XMSegmentedControl_Tests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.$(PRODUCT_NAME:rfc1034identifier)";

--- a/Example/XMSegmentedControl/ViewController.swift
+++ b/Example/XMSegmentedControl/ViewController.swift
@@ -53,7 +53,7 @@ class ViewController: UIViewController, XMSegmentedControlDelegate {
         let titles8 = ["Hello", "World", "Eight"]
 
         // SegmentedControl8
-        let segmentedControl8 = XMSegmentedControl(frame: CGRect(x: 0, y: 164, width: self.view.frame.width, height: 44), verticalSegmentContent: (titles8, icons), selectedItemHighlightStyle: XMSelectedItemHighlightStyle.BottomEdge)
+        let segmentedControl8 = XMSegmentedControl(frame: CGRect(x: 0, y: 164, width: self.view.frame.width, height: 54), verticalSegmentContent: (titles8, icons), selectedItemHighlightStyle: XMSelectedItemHighlightStyle.BottomEdge)
         segmentedControl8.backgroundColor = backgroundColor8
         segmentedControl8.highlightColor = highlightColor8
         segmentedControl8.tint = UIColor.whiteColor()
@@ -63,7 +63,7 @@ class ViewController: UIViewController, XMSegmentedControlDelegate {
         
         // SegmentedControl3
         
-        let segmentedControl3 = XMSegmentedControl(frame: CGRect(x: 0, y: 214, width: self.view.frame.width, height: 44), segmentTitle: ["Hello", "World", "Three"], selectedItemHighlightStyle: XMSelectedItemHighlightStyle.TopEdge)
+        let segmentedControl3 = XMSegmentedControl(frame: CGRect(x: 0, y: 224, width: self.view.frame.width, height: 44), segmentTitle: ["Hello", "World", "Three"], selectedItemHighlightStyle: XMSelectedItemHighlightStyle.TopEdge)
         segmentedControl3.backgroundColor = UIColor(red: 22/255, green: 150/255, blue: 122/255, alpha: 1)
         segmentedControl3.highlightColor = UIColor(red: 25/255, green: 180/255, blue: 145/255, alpha: 1)
         segmentedControl3.tint = UIColor.whiteColor()
@@ -73,7 +73,7 @@ class ViewController: UIViewController, XMSegmentedControlDelegate {
         // SegmentedControl4
         
         let icons1:[UIImage] = [UIImage(named: "icon1")!, UIImage(named: "icon2")!, UIImage(named: "icon3")!, UIImage(named: "icon4")!, UIImage(named: "icon5")!, UIImage(named: "icon6")!]
-        let segmentedControl4 = XMSegmentedControl(frame: CGRect(x: 0, y: 264, width: self.view.frame.width, height: 44), segmentIcon: icons1, selectedItemHighlightStyle: XMSelectedItemHighlightStyle.Background)
+        let segmentedControl4 = XMSegmentedControl(frame: CGRect(x: 0, y: 274, width: self.view.frame.width, height: 44), segmentIcon: icons1, selectedItemHighlightStyle: XMSelectedItemHighlightStyle.Background)
         segmentedControl4.backgroundColor = UIColor(red: 128/255, green: 59/255, blue: 159/255, alpha: 1)
         segmentedControl4.highlightColor = UIColor(red: 144/255, green: 79/255, blue: 173/255, alpha: 1)
         segmentedControl4.tint = UIColor.whiteColor()
@@ -82,7 +82,7 @@ class ViewController: UIViewController, XMSegmentedControlDelegate {
         // SegmentedControl5
         
         let icons2:[UIImage] = [UIImage(named: "icon2")!, UIImage(named: "icon3")!, UIImage(named: "icon4")!, UIImage(named: "icon5")!, UIImage(named: "icon6")!, UIImage(named: "icon7")!, UIImage(named: "icon1")!]
-        let segmentedControl5 = XMSegmentedControl(frame: CGRect(x: 0, y: 314, width: self.view.frame.width, height: 44), segmentIcon: icons2, selectedItemHighlightStyle: XMSelectedItemHighlightStyle.BottomEdge)
+        let segmentedControl5 = XMSegmentedControl(frame: CGRect(x: 0, y: 324, width: self.view.frame.width, height: 44), segmentIcon: icons2, selectedItemHighlightStyle: XMSelectedItemHighlightStyle.BottomEdge)
         segmentedControl5.backgroundColor = UIColor(red: 184/255, green: 50/255, blue: 38/255, alpha: 1)
         segmentedControl5.highlightColor = UIColor(red: 228/255, green: 66/255, blue: 53/255, alpha: 1)
         segmentedControl5.tint = UIColor.whiteColor()
@@ -91,7 +91,7 @@ class ViewController: UIViewController, XMSegmentedControlDelegate {
         // SegmentedControl6
         
         let icons3:[UIImage] = [UIImage(named: "icon2")!, UIImage(named: "icon3")!, UIImage(named: "icon4")!, UIImage(named: "icon5")!, UIImage(named: "icon6")!]
-        let segmentedControl6 = XMSegmentedControl(frame: CGRect(x: 0, y: 364, width: self.view.frame.width, height: 44), segmentIcon: icons3, selectedItemHighlightStyle: XMSelectedItemHighlightStyle.TopEdge)
+        let segmentedControl6 = XMSegmentedControl(frame: CGRect(x: 0, y: 374, width: self.view.frame.width, height: 44), segmentIcon: icons3, selectedItemHighlightStyle: XMSelectedItemHighlightStyle.TopEdge)
         segmentedControl6.backgroundColor = UIColor(red: 35/255, green: 164/255, blue: 85/255, alpha: 1)
         segmentedControl6.highlightColor = UIColor(red: 41/255, green: 197/255, blue: 102/255, alpha: 1)
         segmentedControl6.tint = UIColor.whiteColor()
@@ -100,7 +100,7 @@ class ViewController: UIViewController, XMSegmentedControlDelegate {
         // SegmentedControl7
         
         let icons4:[UIImage] = [UIImage(named: "icon2")!, UIImage(named: "icon3")!, UIImage(named: "icon4")!, UIImage(named: "icon5")!]
-        let segmentedControl7 = XMSegmentedControl(frame: CGRect(x: 0, y: 414, width: self.view.frame.width, height: 44), segmentIcon: icons4, selectedItemHighlightStyle: XMSelectedItemHighlightStyle.Background)
+        let segmentedControl7 = XMSegmentedControl(frame: CGRect(x: 0, y: 424, width: self.view.frame.width, height: 44), segmentIcon: icons4, selectedItemHighlightStyle: XMSelectedItemHighlightStyle.Background)
         segmentedControl7.backgroundColor = UIColor(red: 39/255, green: 54/255, blue: 70/255, alpha: 1)
         segmentedControl7.highlightColor = UIColor(red: 118/255, green: 201/255, blue: 220/255, alpha: 1)
         segmentedControl7.tint = UIColor.whiteColor()

--- a/Example/XMSegmentedControl/ViewController.swift
+++ b/Example/XMSegmentedControl/ViewController.swift
@@ -46,10 +46,24 @@ class ViewController: UIViewController, XMSegmentedControlDelegate {
         segmentedControl2.highlightTint = UIColor.blackColor()
         
         self.view.addSubview(segmentedControl2)
+
+        let backgroundColor8 = UIColor(red: 160/255, green: 74/255, blue: 1/255, alpha: 1)
+        let highlightColor8 = UIColor(red: 181/255, green: 114/255, blue: 31/255, alpha: 1)
+
+        let titles8 = ["Hello", "World", "Eight"]
+
+        // SegmentedControl8
+        let segmentedControl8 = XMSegmentedControl(frame: CGRect(x: 0, y: 164, width: self.view.frame.width, height: 44), verticalSegmentContent: (titles8, icons), selectedItemHighlightStyle: XMSelectedItemHighlightStyle.BottomEdge)
+        segmentedControl8.backgroundColor = backgroundColor8
+        segmentedControl8.highlightColor = highlightColor8
+        segmentedControl8.tint = UIColor.whiteColor()
+        segmentedControl8.highlightTint = UIColor.blackColor()
+
+        self.view.addSubview(segmentedControl8)
         
         // SegmentedControl3
         
-        let segmentedControl3 = XMSegmentedControl(frame: CGRect(x: 0, y: 164, width: self.view.frame.width, height: 44), segmentTitle: ["Hello", "World", "Three"], selectedItemHighlightStyle: XMSelectedItemHighlightStyle.TopEdge)
+        let segmentedControl3 = XMSegmentedControl(frame: CGRect(x: 0, y: 214, width: self.view.frame.width, height: 44), segmentTitle: ["Hello", "World", "Three"], selectedItemHighlightStyle: XMSelectedItemHighlightStyle.TopEdge)
         segmentedControl3.backgroundColor = UIColor(red: 22/255, green: 150/255, blue: 122/255, alpha: 1)
         segmentedControl3.highlightColor = UIColor(red: 25/255, green: 180/255, blue: 145/255, alpha: 1)
         segmentedControl3.tint = UIColor.whiteColor()
@@ -59,7 +73,7 @@ class ViewController: UIViewController, XMSegmentedControlDelegate {
         // SegmentedControl4
         
         let icons1:[UIImage] = [UIImage(named: "icon1")!, UIImage(named: "icon2")!, UIImage(named: "icon3")!, UIImage(named: "icon4")!, UIImage(named: "icon5")!, UIImage(named: "icon6")!]
-        let segmentedControl4 = XMSegmentedControl(frame: CGRect(x: 0, y: 214, width: self.view.frame.width, height: 44), segmentIcon: icons1, selectedItemHighlightStyle: XMSelectedItemHighlightStyle.Background)
+        let segmentedControl4 = XMSegmentedControl(frame: CGRect(x: 0, y: 264, width: self.view.frame.width, height: 44), segmentIcon: icons1, selectedItemHighlightStyle: XMSelectedItemHighlightStyle.Background)
         segmentedControl4.backgroundColor = UIColor(red: 128/255, green: 59/255, blue: 159/255, alpha: 1)
         segmentedControl4.highlightColor = UIColor(red: 144/255, green: 79/255, blue: 173/255, alpha: 1)
         segmentedControl4.tint = UIColor.whiteColor()
@@ -68,7 +82,7 @@ class ViewController: UIViewController, XMSegmentedControlDelegate {
         // SegmentedControl5
         
         let icons2:[UIImage] = [UIImage(named: "icon2")!, UIImage(named: "icon3")!, UIImage(named: "icon4")!, UIImage(named: "icon5")!, UIImage(named: "icon6")!, UIImage(named: "icon7")!, UIImage(named: "icon1")!]
-        let segmentedControl5 = XMSegmentedControl(frame: CGRect(x: 0, y: 264, width: self.view.frame.width, height: 44), segmentIcon: icons2, selectedItemHighlightStyle: XMSelectedItemHighlightStyle.BottomEdge)
+        let segmentedControl5 = XMSegmentedControl(frame: CGRect(x: 0, y: 314, width: self.view.frame.width, height: 44), segmentIcon: icons2, selectedItemHighlightStyle: XMSelectedItemHighlightStyle.BottomEdge)
         segmentedControl5.backgroundColor = UIColor(red: 184/255, green: 50/255, blue: 38/255, alpha: 1)
         segmentedControl5.highlightColor = UIColor(red: 228/255, green: 66/255, blue: 53/255, alpha: 1)
         segmentedControl5.tint = UIColor.whiteColor()
@@ -77,7 +91,7 @@ class ViewController: UIViewController, XMSegmentedControlDelegate {
         // SegmentedControl6
         
         let icons3:[UIImage] = [UIImage(named: "icon2")!, UIImage(named: "icon3")!, UIImage(named: "icon4")!, UIImage(named: "icon5")!, UIImage(named: "icon6")!]
-        let segmentedControl6 = XMSegmentedControl(frame: CGRect(x: 0, y: 314, width: self.view.frame.width, height: 44), segmentIcon: icons3, selectedItemHighlightStyle: XMSelectedItemHighlightStyle.TopEdge)
+        let segmentedControl6 = XMSegmentedControl(frame: CGRect(x: 0, y: 364, width: self.view.frame.width, height: 44), segmentIcon: icons3, selectedItemHighlightStyle: XMSelectedItemHighlightStyle.TopEdge)
         segmentedControl6.backgroundColor = UIColor(red: 35/255, green: 164/255, blue: 85/255, alpha: 1)
         segmentedControl6.highlightColor = UIColor(red: 41/255, green: 197/255, blue: 102/255, alpha: 1)
         segmentedControl6.tint = UIColor.whiteColor()
@@ -86,13 +100,13 @@ class ViewController: UIViewController, XMSegmentedControlDelegate {
         // SegmentedControl7
         
         let icons4:[UIImage] = [UIImage(named: "icon2")!, UIImage(named: "icon3")!, UIImage(named: "icon4")!, UIImage(named: "icon5")!]
-        let segmentedControl7 = XMSegmentedControl(frame: CGRect(x: 0, y: 364, width: self.view.frame.width, height: 44), segmentIcon: icons4, selectedItemHighlightStyle: XMSelectedItemHighlightStyle.Background)
+        let segmentedControl7 = XMSegmentedControl(frame: CGRect(x: 0, y: 414, width: self.view.frame.width, height: 44), segmentIcon: icons4, selectedItemHighlightStyle: XMSelectedItemHighlightStyle.Background)
         segmentedControl7.backgroundColor = UIColor(red: 39/255, green: 54/255, blue: 70/255, alpha: 1)
         segmentedControl7.highlightColor = UIColor(red: 118/255, green: 201/255, blue: 220/255, alpha: 1)
         segmentedControl7.tint = UIColor.whiteColor()
         segmentedControl7.highlightTint = UIColor(red: 39/255, green: 54/255, blue: 70/255, alpha: 1)
         self.view.addSubview(segmentedControl7)
-        
+
     }
 
     override func didReceiveMemoryWarning() {

--- a/Pod/Classes/XMSegmentedControl.swift
+++ b/Pod/Classes/XMSegmentedControl.swift
@@ -252,16 +252,20 @@ public class XMSegmentedControl: UIView {
                     tab.titleLabel?.font = font
                     tab.imageView?.contentMode = .ScaleAspectFit
                     tab.tintColor = i == selectedSegment ? highlightTint : tint
+
                 case .HybridVertical:
                     let insetAmount: CGFloat = 8 / 2.0
-                    let bottomImageInset: CGFloat = 20
-                    let bottomTitleInset: CGFloat = bottomImageInset
-                    tab.imageEdgeInsets = UIEdgeInsetsMake(insetAmount, width - insetAmount*2, bottomImageInset, width - insetAmount)
-                    tab.titleEdgeInsets = UIEdgeInsetsMake(height - bottomTitleInset, -12, insetAmount*2, 12)
+                    let bottomTitleInset: CGFloat = 20
+
+                    let image: UIImage = segmentContent.icon[i]
+                    let imageSize = image.size
+
+                    tab.imageEdgeInsets = UIEdgeInsetsMake(insetAmount, (width - imageSize.width)/2, height - (imageSize.height + insetAmount), (width - imageSize.width)/2)
+                    tab.titleEdgeInsets = UIEdgeInsetsMake(height - bottomTitleInset, -10, insetAmount*2, 10)
                     tab.contentEdgeInsets = UIEdgeInsetsMake(0, insetAmount, 0, insetAmount)
                     tab.contentHorizontalAlignment = .Center
                     tab.setTitle(segmentContent.text[i], forState: .Normal)
-                    tab.setImage(segmentContent.icon[i], forState: .Normal)
+                    tab.setImage(image, forState: .Normal)
                     tab.titleLabel?.font = UIFont(name: font.fontName, size: font.pointSize / 2.0)
                     tab.imageView?.contentMode = .ScaleAspectFit
                     tab.tintColor = i == selectedSegment ? highlightTint : tint
@@ -353,8 +357,10 @@ public class XMSegmentedControl: UIView {
     }
     
     /// Scales an Image to the size provided. It takes into account alpha. And it uses the screen's scale to resize.
-    private func resizeImage(image: UIImage) -> UIImage {
-        let size = CGSize(width: 20, height: 20)
+    private func resizeImage(image:UIImage) -> UIImage {
+        let maxSize = CGSize(width: 20.0, height: 20.0)
+        let ratio = image.size.width / image.size.height
+        let size = CGSize(width: maxSize.width*ratio, height: maxSize.height)
         UIGraphicsBeginImageContextWithOptions(size, false, 0)
         image.drawInRect(CGRect(origin: CGPointZero, size: size))
         let scaledImage = UIGraphicsGetImageFromCurrentImageContext()

--- a/Pod/Classes/XMSegmentedControl.swift
+++ b/Pod/Classes/XMSegmentedControl.swift
@@ -254,8 +254,10 @@ public class XMSegmentedControl: UIView {
                     tab.tintColor = i == selectedSegment ? highlightTint : tint
                 case .HybridVertical:
                     let insetAmount: CGFloat = 8 / 2.0
-                    tab.imageEdgeInsets = UIEdgeInsetsMake(insetAmount / 2.0, width - insetAmount*2, 16, width - insetAmount)
-                    tab.titleEdgeInsets = UIEdgeInsetsMake(height - insetAmount*2, -12, insetAmount*2, 12)
+                    let bottomImageInset: CGFloat = 20
+                    let bottomTitleInset: CGFloat = bottomImageInset
+                    tab.imageEdgeInsets = UIEdgeInsetsMake(insetAmount, width - insetAmount*2, bottomImageInset, width - insetAmount)
+                    tab.titleEdgeInsets = UIEdgeInsetsMake(height - bottomTitleInset, -12, insetAmount*2, 12)
                     tab.contentEdgeInsets = UIEdgeInsetsMake(0, insetAmount, 0, insetAmount)
                     tab.contentHorizontalAlignment = .Center
                     tab.setTitle(segmentContent.text[i], forState: .Normal)

--- a/Pod/Classes/XMSegmentedControl.swift
+++ b/Pod/Classes/XMSegmentedControl.swift
@@ -32,11 +32,13 @@ public enum XMSelectedItemHighlightStyle {
  - Text: The segmented control displays only text.
  - Icon: The segmented control displays only icons/images.
  - Hybrid: The segmented control displays icons and text.
+ - HybridVertical: The segmented control displays icons and text in vertical arrangement.
  */
 public enum XMContentType {
     case Text
     case Icon
     case Hybrid
+    case HybridVertical
 }
 
 @IBDesignable
@@ -125,6 +127,18 @@ public class XMSegmentedControl: UIView {
             self.update()
         }
     }
+
+    /**
+     Sets the segmented control content type to `HybridVertical` (i.e. displaying icons and text in vertical arrangement) and uses the content of the tuple to create the segments.
+     - Note: Only six elements will be displayed.
+     */
+
+    public func setupVerticalSegmentContent(content: (text: [String], icon: [UIImage])) {
+        segmentContent = content
+
+        contentType = .HybridVertical
+        self.update()
+    }
     
     
     /// The segment index of the selected item.
@@ -161,6 +175,16 @@ public class XMSegmentedControl: UIView {
         super.init (frame: frame)
 
         self.commonInit(segmentContent, highlightStyle: selectedItemHighlightStyle)
+    }
+
+    /**
+     Initializes and returns a newly allocated XMSegmentedControl object with the specified frame rectangle. It sets the segments of the control from the given `verticalSegmentContent` tuple and the highlight style for the selected item. Notice that the tuple consists of an array containing the titles and another array containing the icons. The two arrays must be the same size.
+
+     The `contentType` is `HybridVertical`
+    */
+    public convenience init (frame: CGRect, verticalSegmentContent: ([String], [UIImage]), selectedItemHighlightStyle:XMSelectedItemHighlightStyle) {
+        self.init (frame: frame, segmentContent: verticalSegmentContent, selectedItemHighlightStyle: selectedItemHighlightStyle)
+        setupVerticalSegmentContent(verticalSegmentContent)
     }
     
     /// Common initializer.
@@ -228,7 +252,17 @@ public class XMSegmentedControl: UIView {
                     tab.titleLabel?.font = font
                     tab.imageView?.contentMode = .ScaleAspectFit
                     tab.tintColor = i == selectedSegment ? highlightTint : tint
-                    
+                case .HybridVertical:
+                    let insetAmount: CGFloat = 8 / 2.0
+                    tab.imageEdgeInsets = UIEdgeInsetsMake(insetAmount / 2.0, width - insetAmount*2, 16, width - insetAmount)
+                    tab.titleEdgeInsets = UIEdgeInsetsMake(height - insetAmount*2, -12, insetAmount*2, 12)
+                    tab.contentEdgeInsets = UIEdgeInsetsMake(0, insetAmount, 0, insetAmount)
+                    tab.contentHorizontalAlignment = .Center
+                    tab.setTitle(segmentContent.text[i], forState: .Normal)
+                    tab.setImage(segmentContent.icon[i], forState: .Normal)
+                    tab.titleLabel?.font = UIFont(name: font.fontName, size: font.pointSize / 2.0)
+                    tab.imageView?.contentMode = .ScaleAspectFit
+                    tab.tintColor = i == selectedSegment ? highlightTint : tint
                 }
                 
                 tab.tag = i
@@ -292,7 +326,7 @@ public class XMSegmentedControl: UIView {
             self.highlightView.frame.origin = newPosition
             
             switch(self.contentType) {
-            case .Icon, .Hybrid:
+            case .Icon, .Hybrid, .HybridVertical:
                 ((self.subviews.filter(isUIButton)) as! [UIButton]).forEach { $0.tintColor = self.tint }
                 sender.tintColor = self.highlightTint
             case .Text:

--- a/Pod/Classes/XMSegmentedControl.swift
+++ b/Pod/Classes/XMSegmentedControl.swift
@@ -261,7 +261,7 @@ public class XMSegmentedControl: UIView {
                     let imageSize = image.size
                     let horizontalInset = (width - imageSize.width)/2
 
-                    tab.imageEdgeInsets = UIEdgeInsetsMake(insetAmount, horizontalInset, height - imageSize.height + insetAmount, horizontalInset)
+                    tab.imageEdgeInsets = UIEdgeInsetsMake(insetAmount*2, horizontalInset, height - imageSize.height + insetAmount, horizontalInset)
                     tab.titleEdgeInsets = UIEdgeInsetsMake(height - bottomTitleInset, -imageSize.width / 2, insetAmount*2, imageSize.width / 2)
                     tab.contentEdgeInsets = UIEdgeInsetsMake(0, insetAmount, 0, insetAmount)
                     tab.contentHorizontalAlignment = .Center

--- a/Pod/Classes/XMSegmentedControl.swift
+++ b/Pod/Classes/XMSegmentedControl.swift
@@ -259,9 +259,10 @@ public class XMSegmentedControl: UIView {
 
                     let image: UIImage = segmentContent.icon[i]
                     let imageSize = image.size
+                    let horizontalInset = (width - imageSize.width)/2
 
-                    tab.imageEdgeInsets = UIEdgeInsetsMake(insetAmount, (width - imageSize.width)/2, height - (imageSize.height + insetAmount), (width - imageSize.width)/2)
-                    tab.titleEdgeInsets = UIEdgeInsetsMake(height - bottomTitleInset, -10, insetAmount*2, 10)
+                    tab.imageEdgeInsets = UIEdgeInsetsMake(insetAmount, horizontalInset, height - imageSize.height + insetAmount, horizontalInset)
+                    tab.titleEdgeInsets = UIEdgeInsetsMake(height - bottomTitleInset, -imageSize.width / 2, insetAmount*2, imageSize.width / 2)
                     tab.contentEdgeInsets = UIEdgeInsetsMake(0, insetAmount, 0, insetAmount)
                     tab.contentHorizontalAlignment = .Center
                     tab.setTitle(segmentContent.text[i], forState: .Normal)
@@ -358,7 +359,7 @@ public class XMSegmentedControl: UIView {
     
     /// Scales an Image to the size provided. It takes into account alpha. And it uses the screen's scale to resize.
     private func resizeImage(image:UIImage) -> UIImage {
-        let maxSize = CGSize(width: 20.0, height: 20.0)
+        let maxSize = CGSize(width: frame.height / 2, height: frame.height / 2)
         let ratio = image.size.width / image.size.height
         let size = CGSize(width: maxSize.width*ratio, height: maxSize.height)
         UIGraphicsBeginImageContextWithOptions(size, false, 0)

--- a/Pod/Classes/XMSegmentedControl.swift
+++ b/Pod/Classes/XMSegmentedControl.swift
@@ -252,7 +252,6 @@ public class XMSegmentedControl: UIView {
                     tab.titleLabel?.font = font
                     tab.imageView?.contentMode = .ScaleAspectFit
                     tab.tintColor = i == selectedSegment ? highlightTint : tint
-
                 case .HybridVertical:
                     let insetAmount: CGFloat = 8 / 2.0
                     let bottomTitleInset: CGFloat = 20

--- a/Pod/Classes/XMSegmentedControl.swift
+++ b/Pod/Classes/XMSegmentedControl.swift
@@ -41,6 +41,18 @@ public enum XMContentType {
     case HybridVertical
 }
 
+/**
+ Content distribution for the segmented control
+ - Fixed: The segmented control item has a fixed width at `totalWidth / 6`, where 6 is maximum number of segment items.
+ - HalfFixed: The segmented control item has a width equal to `totalWidth / 6`, if number of segment items > 2, and `totalWidth / 4` otherwise.
+ - Flexible: The segmented control item has a width equal to `totalWidth / segmentCount`
+ */
+public enum XMSegmentItemWidthDistribution {
+    case Fixed
+    case HalfFixed
+    case Flexible
+}
+
 @IBDesignable
 public class XMSegmentedControl: UIView {
 
@@ -155,6 +167,9 @@ public class XMSegmentedControl: UIView {
     
     /// Sets the segmented control content type to `Text` or `Icon`
     public var contentType: XMContentType = .Text
+
+    /// Sets the segmented control item width distribution to `Fixed`, `HalfFixed` or `Flexible`
+    public var itemWidthDistribution:XMSegmentItemWidthDistribution = .Flexible
     
     /// Initializes and returns a newly allocated XMSegmentedControl object with the specified frame rectangle. It sets the segments of the control from the given `segmentTitle` array and the highlight style for the selected item.
     public init (frame: CGRect, segmentTitle: [String], selectedItemHighlightStyle: XMSelectedItemHighlightStyle) {
@@ -294,6 +309,30 @@ public class XMSegmentedControl: UIView {
         (subviews as [UIView]).forEach { $0.removeFromSuperview() }
         let totalWidth = frame.width
 
+        func startingPositionAndWidth(totalWidth: CGFloat, distribution: XMSegmentItemWidthDistribution, segmentCount: Int, selectedIndex: Int) -> (startingPosition: CGFloat, sectionWidth: CGFloat) {
+
+            switch distribution {
+            case .Fixed:
+                let width = totalWidth / 6
+                let availableSpace = totalWidth - (width * CGFloat(segmentCount))
+                let position = (totalWidth - availableSpace) / 2
+                return (position, width)
+            case .HalfFixed:
+                var width = totalWidth / 4
+                if segmentCount > 2 {
+                    width = totalWidth / 6
+                }
+
+                let availableSpace = totalWidth - (width * CGFloat(segmentCount))
+                let position = (totalWidth - availableSpace) / 2
+                return (position, width)
+            case .Flexible:
+                let width = totalWidth / CGFloat(segmentCount)
+                let position = CGFloat(selectedIndex) * width
+                return (position, width)
+            }
+        }
+
         if contentType == .Text {
             guard segmentTitle.count > 0 else {
                 print("segment titles (segmentTitle) are not set")
@@ -305,17 +344,20 @@ public class XMSegmentedControl: UIView {
             addHighlightView(startingPosition: CGFloat(selectedSegment) * sectionWidth, width: sectionWidth)
             addSegments(startingPosition: 0, sections: tabBarSections, width: sectionWidth, height: frame.height)
         } else if contentType == .Icon {
-            let tabBarSections = segmentIcon.count
-            let sectionWidth = totalWidth / 6
-            let availableSpace = totalWidth - (sectionWidth * CGFloat(6 - tabBarSections))
-            let startingXPosition = (totalWidth - availableSpace) / 2
-            addHighlightView(startingPosition: startingXPosition + (sectionWidth * CGFloat(selectedSegment)), width: sectionWidth)
-            addSegments(startingPosition: startingXPosition, sections: tabBarSections, width: sectionWidth, height: frame.height)
-        } else { // Hybrid
-            let tabBarSections = segmentContent.text.count
-            let sectionWidth = totalWidth / CGFloat(tabBarSections)
-            addHighlightView(startingPosition: CGFloat(selectedSegment) * sectionWidth, width: sectionWidth)
-            addSegments(startingPosition: 0, sections: tabBarSections, width: sectionWidth, height: frame.height)
+            let tabBarSections:Int = segmentIcon.count
+            let positionWidth = startingPositionAndWidth(totalWidth, distribution: itemWidthDistribution, segmentCount: tabBarSections, selectedIndex: selectedSegment)
+            addHighlightView(startingPosition: positionWidth.startingPosition, width: positionWidth.sectionWidth)
+            addSegments(startingPosition: positionWidth.startingPosition, sections: tabBarSections, width: positionWidth.sectionWidth, height: self.frame.height)
+        } else if contentType == .Hybrid {
+            let tabBarSections:Int = segmentContent.text.count
+            let positionWidth = startingPositionAndWidth(totalWidth, distribution: itemWidthDistribution, segmentCount: tabBarSections, selectedIndex: selectedSegment)
+            addHighlightView(startingPosition: positionWidth.startingPosition, width: positionWidth.sectionWidth)
+            addSegments(startingPosition: 0, sections: tabBarSections, width: positionWidth.sectionWidth, height: self.frame.height)
+        } else if contentType == .HybridVertical {
+            let tabBarSections:Int = segmentContent.text.count
+            let positionWidth = startingPositionAndWidth(totalWidth, distribution: itemWidthDistribution, segmentCount: tabBarSections, selectedIndex: selectedSegment)
+            addHighlightView(startingPosition: positionWidth.startingPosition, width: positionWidth.sectionWidth)
+            addSegments(startingPosition: positionWidth.startingPosition, sections: tabBarSections, width: positionWidth.sectionWidth, height: self.frame.height)
         }
     }
     


### PR DESCRIPTION
Content distribution for the segmented control
- Fixed: The segmented control item has a fixed width at `totalWidth / 6`, where 6 is maximum number of segment items.
- HalfFixed: The segmented control item has a width equal to `totalWidth / 6`, if number of segment items > 2, and `totalWidth / 4` otherwise.
- Flexible: The segmented control item has a width equal to `totalWidth / segmentCount`
