### PR TITLE
Add Custom Inset Properties, Option to Disable Image Resizing, Provide Segment Borders

### DIFF
--- a/Pod/Classes/XMSegmentedControl.swift
+++ b/Pod/Classes/XMSegmentedControl.swift
@@ -128,6 +128,16 @@ public class XMSegmentedControl: UIView {
             self.update()
         }
     }
+
+    /**
+     Whether or not icons are resized before being used in Hybrid mode.
+     - Note: If you don't want your icons resized, you _must_ set this
+     _before_ providing the icons via segmentContent. By default, resizing
+     is enabled. This means you can't disable resizing when using one of
+     the convenience initializers at the moment. I wanted to provide this
+     option without cluttering up the initializers.
+    */
+    public var resizeContentIcons: Bool = true
     
     /**
      Sets the segmented control content type to `Hybrid` (i.e. displaying icons and text) and uses the content of the tuple to create the segments.
@@ -152,7 +162,9 @@ public class XMSegmentedControl: UIView {
                 segmentContent.icon = segmentContent.icon
             }
 
-            segmentContent.icon = segmentContent.icon.map(resizeImage)
+            if resizeContentIcons {
+                segmentContent.icon = segmentContent.icon.map(resizeImage)
+            }
 
             contentType = .Hybrid
             self.update()

--- a/Pod/Classes/XMSegmentedControl.swift
+++ b/Pod/Classes/XMSegmentedControl.swift
@@ -97,6 +97,16 @@ public class XMSegmentedControl: UIView {
             self.update()
         }
     }
+
+
+    /**
+     Sets the image insets for the titles.
+     */
+    public var titleInsets: UIEdgeInsets = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 0) {
+        didSet {
+            self.update()
+        }
+    }
     
     /**
      Sets the segmented control content type to `Icon` and uses the content of the array to create the segments.
@@ -289,7 +299,7 @@ public class XMSegmentedControl: UIView {
                 case .Hybrid:
                     let insetAmount: CGFloat = 8 / 2.0
                     tab.imageEdgeInsets = UIEdgeInsetsMake(12, -insetAmount, 12, insetAmount)
-                    tab.titleEdgeInsets = UIEdgeInsetsMake(0, insetAmount*2, 0, 0)
+                    tab.titleEdgeInsets = titleInsets
                     tab.contentEdgeInsets = UIEdgeInsetsMake(0, insetAmount, 0, insetAmount)
                     tab.contentHorizontalAlignment = .Center
                     tab.setTitle(segmentContent.text[i], forState: .Normal)

--- a/Pod/Classes/XMSegmentedControl.swift
+++ b/Pod/Classes/XMSegmentedControl.swift
@@ -119,6 +119,15 @@ public class XMSegmentedControl: UIView {
             self.update()
         }
     }
+
+    /**
+     Sets the image insets for the icons.
+    */
+    public var iconInsets: UIEdgeInsets = UIEdgeInsets(top: 12, left: 12, bottom: 12, right: 12) {
+        didSet {
+            self.update()
+        }
+    }
     
     /**
      Sets the segmented control content type to `Hybrid` (i.e. displaying icons and text) and uses the content of the tuple to create the segments.
@@ -288,7 +297,7 @@ public class XMSegmentedControl: UIView {
                 
                 switch contentType {
                 case .Icon:
-                    tab.imageEdgeInsets = UIEdgeInsets(top: 12, left: 12, bottom: 12, right: 12)
+                    tab.imageEdgeInsets = iconInsets
                     tab.imageView?.contentMode = UIViewContentMode.ScaleAspectFit
                     tab.tintColor = i == selectedSegment ? highlightTint : tint
                     tab.setImage(segmentIcon[i], forState: .Normal)
@@ -298,7 +307,7 @@ public class XMSegmentedControl: UIView {
                     tab.titleLabel?.font = font
                 case .Hybrid:
                     let insetAmount: CGFloat = 8 / 2.0
-                    tab.imageEdgeInsets = UIEdgeInsetsMake(12, -insetAmount, 12, insetAmount)
+                    tab.imageEdgeInsets = iconInsets
                     tab.titleEdgeInsets = titleInsets
                     tab.contentEdgeInsets = UIEdgeInsetsMake(0, insetAmount, 0, insetAmount)
                     tab.contentHorizontalAlignment = .Center

--- a/Pod/Classes/XMSegmentedControl.swift
+++ b/Pod/Classes/XMSegmentedControl.swift
@@ -138,6 +138,15 @@ public class XMSegmentedControl: UIView {
      option without cluttering up the initializers.
     */
     public var resizeContentIcons: Bool = true
+
+    /**
+     Set the border color and width of the segments.
+    */
+    public var segmentBorders: (color: UIColor, width: CGFloat) = (UIColor.clearColor(), 0) {
+        didSet {
+            self.update()
+        }
+    }
     
     /**
      Sets the segmented control content type to `Hybrid` (i.e. displaying icons and text) and uses the content of the tuple to create the segments.
@@ -306,6 +315,9 @@ public class XMSegmentedControl: UIView {
                 let frame = CGRect(x: starting + (CGFloat(i) * width), y: 0, width: width, height: height)
                 let tab = UIButton(type: UIButtonType.System)
                 tab.frame = frame
+
+                tab.layer.borderColor = segmentBorders.color.CGColor
+                tab.layer.borderWidth = segmentBorders.width
                 
                 switch contentType {
                 case .Icon:


### PR DESCRIPTION
Borrowing from the approach @randybyrd322 made in #19, this adds properties to provide custom insets for finger-grained control over positioning. Unfortunately, our two pull requests won't play nicely together. I'd be happy to modify mine as necessary to make it work though.

Also, I haven't had a chance to look at how the vertical hybrid style works, so it doesn't modify the insets for that at all. I think semantically, the way contentInsets are done now also aren't quite correct (in plain hybrid, at least...I think it should probably do some combination of the two provided insets somehow).

Also, I added an option to disable the image resizing, as it was making getting the icons to look good challenging for me.

Feedback and suggestions are welcome, I'm happy to modify / improve the PR as necessary. Thanks for the useful / great project! 👍 
